### PR TITLE
ci(renovate): use custom datasources for better version change detection

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,14 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "regexManagers:githubActionsVersions",
   ],
+  "customDatasources": {
+    "omnitruck": {
+      "defaultRegistryUrlTemplate": "https://omnitruck.chef.io/stable/{{packageName}}/versions/latest",
+      "transformTemplates": [
+        "{\"releases\": [{ \"version\": $string($) }] }",
+      ],
+    },
+  },
   "packageRules": [
     {
       "matchPackageNames": ["actions/python-versions"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,12 @@
         "{\"releases\": [{ \"version\": $string($) }] }",
       ],
     },
+    "python-versions": {
+      "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/actions/python-versions/refs/heads/main/versions-manifest.json",
+      "transformTemplates": [
+        "{\"releases\": $ }",
+      ],
+    },
   },
   "packageRules": [
     {

--- a/.github/workflows/libbuild.yml
+++ b/.github/workflows/libbuild.yml
@@ -79,7 +79,7 @@ jobs:
         if: ${{ !startsWith(runner.name, 'self') }}
         uses: actionshub/chef-install@d41f8dde8642d5cd05abefa333fbf2784cff830c # 3.0.0
         env:
-          # renovate: datasource=github-tags depName=chef/chef-workstation
+          # renovate: datasource=custom.omnitruck depName=chef-workstation
           CHEF_WS_VERSION: 24.8.1068
         with:
           project: chef-workstation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      # renovate: datasource=github-releases depName=actions/python-versions extractVersion=^(?<version>\S+)-\d+$
+      # renovate: datasource=custom.python-versions depName=actions/python-versions versioning=pep440
       PYTHON_VERSION: 3.13.0
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
- **ci(renovate): prevent failed updates by reading the actual available Chef Workstation version**
- **ci(renovate): prevent failed updates by reading the actual available Python version**
