### PR TITLE
fix(workflows): allow use of Hashicorp Cloud Platform Vagrant Registry

### DIFF
--- a/.github/workflows/libbuild.yml
+++ b/.github/workflows/libbuild.yml
@@ -103,6 +103,7 @@ jobs:
         if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         env:
           PACKER_COMMAND: ${{ inputs.upload-box && 'build -timestamp-ui' || 'validate' }}
-          VAGRANT_CLOUD_TOKEN: ${{ secrets.VAGRANT_CLOUD_TOKEN }}
+          HCP_CLIENT_ID: ${{ secrets.HCP_CLIENT_ID }}
+          HCP_CLIENT_SECRET: ${{ secrets.HCP_CLIENT_SECRET }}
         run: |
           packer $PACKER_COMMAND -only \*.${{ inputs.build-os-version }} -var version=$(bin/version) -var prefix= -var no_release=false -var box_dir=box/${{ inputs.build-type }} upload


### PR DESCRIPTION
BREAKING CHANGE: accept secrets HCP_CLIENT_ID & HCP_CLIENT_SECRET instead of VAGRANT_CLOUD_TOKEN
