### PR TITLE
ci(workflows): use GitHub Ubuntu runner instead of BuildJet

### DIFF
--- a/.github/workflows/libbuild.yml
+++ b/.github/workflows/libbuild.yml
@@ -63,6 +63,9 @@ jobs:
           kernel_name=$(uname -s)
           if [ "$kernel_name" == "Linux" ]; then
             echo PKR_VAR_accelerator=kvm >> $GITHUB_ENV
+            echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger --name-match=kvm
           elif [ "$kernel_name" == "Darwin" ]; then
             : # No action needed for Darwin
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         build-os-version: ${{ fromJSON(needs.gov.outputs.os-versions) }}
-        build-runner: [buildjet-2vcpu-ubuntu-2204, virtualbox]
+        build-runner: [ubuntu-24.04, virtualbox]
         build-type: ${{ fromJSON(needs.gbt.outputs.build-types) }}
         exclude:
           - build-type: qemu-x64
@@ -89,7 +89,7 @@ jobs:
           - build-type: vbox-x64
             build-runner: buildjet-2vcpu-ubuntu-2204
           - build-type: vbox-x64
-            build-runner: ubuntu-latest
+            build-runner: ubuntu-24.04
     with:
       build-os-version: ${{ matrix.build-os-version }}
       build-runner: ${{ matrix.build-runner }}


### PR DESCRIPTION
* as BuildJet seems to be lagging on Runner image versions
